### PR TITLE
Map a better name for '123' icon

### DIFF
--- a/MaterialDesignIcons.cs
+++ b/MaterialDesignIcons.cs
@@ -40,7 +40,7 @@ namespace MaterialDesign
         /// <para/>
         /// <see href="https://fonts.google.com/icons?selected=Material+Icons:123"/>.
         /// </summary>
-        public const string OneHundred_And_TwentyThree = "\ueb8d";
+        public const string OneTwoThree = "\ueb8d";
 
         /// <summary>
         /// Unicode value for the '12mp' icon ("\ue954").

--- a/md2cs/Helpers/DotNetNameHelper.cs
+++ b/md2cs/Helpers/DotNetNameHelper.cs
@@ -10,7 +10,8 @@ namespace md2cs.Helpers
         {
             { "3d_rotation", "Rotation3D" },
             { "360", "ThreeSixty"},
-            { "3p", "ThirdPerson"}
+            { "3p", "ThirdPerson"},
+            { "123", "OneTwoThree"}
         };
 
         private static readonly IReadOnlyDictionary<string, string> SuffixMap = new Dictionary<string, string>


### PR DESCRIPTION
One of the new icons from the last update had an auto-generated name which wasn't too great. This replaces it with a better name by adding a custom mapping (and updates MaterialDesignIcons.cs to match).